### PR TITLE
Updated to axum 0.7.1, dropped http-body dependency

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "wasm32-unknown-unknown"

--- a/adapter/Cargo.toml
+++ b/adapter/Cargo.toml
@@ -17,7 +17,6 @@ crate-type = ["cdylib", "lib"]
 [dependencies]
 axum = { version = "^0.7.1", default-features = false }
 worker = { version = "^0.0.18" }
-http-body = "^0.4.5"
 axum-wasm-macros = "^0.1.0"
 futures = "0.3.29"
 

--- a/adapter/Cargo.toml
+++ b/adapter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-cloudflare-adapter"
-version = "0.6.1"
+version = "0.7.1"
 edition = "2021"
 authors = ["Logan Keenan"]
 description = "An adapter to easily run an Axum server in a Cloudflare worker."
@@ -15,10 +15,11 @@ crate-type = ["cdylib", "lib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum = { version = "^0.6.19", default-features = false }
+axum = { version = "^0.7.1", default-features = false }
 worker = { version = "^0.0.18" }
 http-body = "^0.4.5"
 axum-wasm-macros = "^0.1.0"
+futures = "0.3.29"
 
 [dev-dependencies]
 wasm-bindgen-test = "^0.3.34"

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "todo-worker"
 version = "0.0.0"
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -11,15 +11,14 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 cfg-if = "1.0.0"
-worker = "0.0.18"
-serde_json = "1.0.96"
-axum = { version = "0.6.16", default-features = false }
-tower-service = "0.3.2"
+axum = { version = "^0.7.1", default-features = false }
 axum-cloudflare-adapter = { path = "../adapter" }
-wasm-bindgen-futures = "0.4.34"
-oneshot = "0.1.5"
+oneshot = "0.1.6"
+serde_json = "1.0.108"
+tower-service = "0.3.2"
 url = "2.3.1"
-
+wasm-bindgen-futures = "0.4.34"
+worker = "0.0.18"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/example/wrangler.toml
+++ b/example/wrangler.toml
@@ -1,9 +1,10 @@
 workers_dev = true
+compatibility_date = "2023-11-29"
 
 main = "build/worker/shim.mjs"
 
 [vars]
-WORKERS_RS_VERSION = "0.1.8"
+WORKERS_RS_VERSION = "0.0.18"
 
 [build]
 command = "cargo install -q worker-build && worker-build --release"

--- a/example/wrangler.toml
+++ b/example/wrangler.toml
@@ -1,9 +1,9 @@
-name = "axum-cloudflare-adapter-example"
+workers_dev = true
+
 main = "build/worker/shim.mjs"
-compatibility_date = "2022-01-20"
 
 [vars]
-WORKERS_RS_VERSION = "0.0.11"
+WORKERS_RS_VERSION = "0.1.8"
 
 [build]
-command = "cargo install -q worker-build --version 0.0.10 && worker-build --release"
+command = "cargo install -q worker-build && worker-build --release"


### PR DESCRIPTION
Hi,

I did my best to update it to support axum 0.7.1.

I also updated the example to axum 0.7.1 and workers 0.0.18.

I executed the tests on chrome, firefox and safari, and tested the example.

I also added .cargo/config.toml
[build]
target = "wasm32-unknown-unknown"

So that it works fine with cargo build and cargo check.

Cheers! Thanks!