### PR TITLE
Updated to the latest worker-rs and latest wrangler

### DIFF
--- a/.github/workflows/build-worker.yml
+++ b/.github/workflows/build-worker.yml
@@ -16,7 +16,7 @@ jobs:
           node-version-file: '.nvmrc'
 
       - name: Install Wrangler
-        run: npm install -g wrangler@3.32.0
+        run: npm install -g wrangler@3.34.2
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1

--- a/adapter/Cargo.toml
+++ b/adapter/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 axum = { version = "^0.7.1", default-features = false }
-worker = { version = "^0.0.20" }
+worker = { version = "^0.0.21" }
 axum-wasm-macros = "^0.1.0"
 futures = "0.3.29"
 

--- a/adapter/README.md
+++ b/adapter/README.md
@@ -4,6 +4,22 @@
 
 An adapter to easily run an [Axum](https://github.com/tokio-rs/axum) server in a Cloudflare worker.
 
+## Cloudflare workers perliminary native support for Axum on 0.0.21+
+
+Its hidden behind the feature flag "http".
+
+This package can be used as an easy way to migrate from the non http version to the http version:
+1. Add the dependency to the adapter and maintain the dependenty to the non http version (http flag disabled)
+2. Add a catch all route to the existing router:
+
+```rust
+    .or_else_any_method_async("/*catchall", |_, ctx| async move {
+```
+3. Inside the catch all route, add an axum router like in the example bellow.
+4. Start to incrementally migrate the paths one by one, from the old router to the axum router.
+5. Once finished, drop the dependency on this adapter and enable the "http" flag on workers-rs.
+6. If you have any issues you can ask for help on #rust-on-workers on discord or open an issue in workers-rs github.
+
 ## Usage
 
 ```rust

--- a/adapter/README.md
+++ b/adapter/README.md
@@ -6,12 +6,14 @@ An adapter to easily run an [Axum](https://github.com/tokio-rs/axum) server in a
 
 ## Cloudflare workers perliminary native support for Axum on 0.0.21+
 
-Its hidden behind the feature flag "http".
+Axum support in workers-rs is enabled by the [http](https://github.com/cloudflare/workers-rs?tab=readme-ov-file#http-feature) feature in worker-rs.
 
-This package can be used as an easy way to migrate from the non http version to the http version:
-1. Add the dependency to the adapter and maintain the dependenty to the non http version (http flag disabled)
+This is possible because both Axum and worker-rs http uses the same [http](https://docs.rs/http/latest/http/) crate.
+
+This adapter can be used as an easy way to migrate from the non http workers-rs version to the http version:
+1. Do not change your current workers-rs project dependency on the non http version of workers-rs (keep the http flag disabled).
+1. Add the dependency to this adapter.
 2. Add a catch all route to the existing router:
-
 ```rust
     .or_else_any_method_async("/*catchall", |_, ctx| async move {
 ```

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = "1.0.108"
 tower-service = "0.3.2"
 url = "2.3.1"
 wasm-bindgen-futures = "0.4.34"
-worker = "0.0.20"
+worker = "^0.0.21"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/example/wrangler.toml
+++ b/example/wrangler.toml
@@ -5,7 +5,7 @@ main = "build/worker/shim.mjs"
 name = "axum-cloudflare-adapter"
 
 [vars]
-WORKERS_RS_VERSION = "0.0.18"
+WORKERS_RS_VERSION = "0.0.21"
 
 [build]
 command = "cargo install -q worker-build && worker-build --release"


### PR DESCRIPTION
Although there is an workers-rs (with the http flag) that supports axum directly, this adapter is still relevant to those porting from the older workers-rs version in an incremental way.