### PR TITLE
Updated to workers 0.0.24.

### DIFF
--- a/adapter/Cargo.toml
+++ b/adapter/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 axum = { version = "^0.7.1", default-features = false }
-worker = { version = "^0.0.21" }
+worker = { version = "^0.0.22" }
 axum-wasm-macros = "^0.1.0"
 futures = "0.3.29"
 

--- a/adapter/Cargo.toml
+++ b/adapter/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 axum = { version = "^0.7.1", default-features = false }
-worker = { version = "^0.0.22" }
+worker = { version = "^0.0.23" }
 axum-wasm-macros = "^0.1.0"
 futures = "0.3.29"
 

--- a/adapter/Cargo.toml
+++ b/adapter/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 axum = { version = "^0.7.1", default-features = false }
-worker = { version = "^0.0.23" }
+worker = { version = "^0.0.24" }
 axum-wasm-macros = "^0.1.0"
 futures = "0.3.29"
 

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = "1.0.108"
 tower-service = "0.3.2"
 url = "2.3.1"
 wasm-bindgen-futures = "0.4.34"
-worker = "^0.0.21"
+worker = "^0.0.22"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = "1.0.108"
 tower-service = "0.3.2"
 url = "2.3.1"
 wasm-bindgen-futures = "0.4.34"
-worker = "^0.0.22"
+worker = "^0.0.23"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = "1.0.108"
 tower-service = "0.3.2"
 url = "2.3.1"
 wasm-bindgen-futures = "0.4.34"
-worker = "^0.0.23"
+worker = "^0.0.24"
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires


### PR DESCRIPTION
Is there a way to avoid having to update everytime?

Its just that releases are going to get common and this adapter is going to continue to be relevant in the near future.

Thanks!